### PR TITLE
[RST-2148] reset all the things

### DIFF
--- a/include/fuse_rl/acceleration_2d/model.h
+++ b/include/fuse_rl/acceleration_2d/model.h
@@ -101,6 +101,16 @@ protected:
    */
   void onInit() override;
 
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
   ParameterType params_;
 
   ros::Subscriber subscriber_;

--- a/include/fuse_rl/acceleration_2d/model.h
+++ b/include/fuse_rl/acceleration_2d/model.h
@@ -113,11 +113,11 @@ protected:
 
   ParameterType params_;
 
-  ros::Subscriber subscriber_;
-
   tf2_ros::Buffer tf_buffer_;
 
   tf2_ros::TransformListener tf_listener_;
+
+  ros::Subscriber subscriber_;
 };
 
 }  // namespace acceleration_2d

--- a/include/fuse_rl/imu_2d/model.h
+++ b/include/fuse_rl/imu_2d/model.h
@@ -119,6 +119,16 @@ protected:
    */
   void onInit() override;
 
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
   ParameterType params_;
 
   std::unique_ptr<geometry_msgs::PoseWithCovarianceStamped> previous_pose_;

--- a/include/fuse_rl/odometry_2d/model.h
+++ b/include/fuse_rl/odometry_2d/model.h
@@ -113,15 +113,25 @@ protected:
    */
   void onInit() override;
 
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
   ParameterType params_;
 
-  ros::Subscriber subscriber_;
+  geometry_msgs::PoseWithCovarianceStamped::Ptr previous_pose_;
 
   tf2_ros::Buffer tf_buffer_;
 
   tf2_ros::TransformListener tf_listener_;
 
-  geometry_msgs::PoseWithCovarianceStamped::Ptr previous_pose_;
+  ros::Subscriber subscriber_;
 };
 
 }  // namespace odometry_2d

--- a/include/fuse_rl/odometry_2d/publisher.h
+++ b/include/fuse_rl/odometry_2d/publisher.h
@@ -108,6 +108,7 @@ public:
    */
   virtual ~Publisher() = default;
 
+protected:
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the
    * parameter server.
@@ -124,7 +125,16 @@ public:
     fuse_core::Transaction::ConstSharedPtr transaction,
     fuse_core::Graph::ConstSharedPtr graph) override;
 
-protected:
+  /**
+   * @brief Perform any required operations before the first call to notify() occurs
+   */
+  void onStart() override;
+
+  /**
+   * @brief Perform any required operations to stop publications
+   */
+  void onStop() override;
+
   /**
    * @brief Retrieves the given variable values at the requested time from the graph
    * @param[in] graph The graph from which we will retrieve the state

--- a/include/fuse_rl/pose_2d/model.h
+++ b/include/fuse_rl/pose_2d/model.h
@@ -104,15 +104,25 @@ protected:
    */
   void onInit() override;
 
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
   ParameterType params_;
 
-  ros::Subscriber subscriber_;
+  geometry_msgs::PoseWithCovarianceStamped::ConstPtr previous_pose_msg_;
 
   tf2_ros::Buffer tf_buffer_;
 
   tf2_ros::TransformListener tf_listener_;
 
-  geometry_msgs::PoseWithCovarianceStamped::ConstPtr previous_pose_msg_;
+  ros::Subscriber subscriber_;
 };
 
 }  // namespace pose_2d

--- a/include/fuse_rl/twist_2d/model.h
+++ b/include/fuse_rl/twist_2d/model.h
@@ -95,13 +95,23 @@ protected:
    */
   void onInit() override;
 
-  ParameterType params_;
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
 
-  ros::Subscriber subscriber_;
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
+  ParameterType params_;
 
   tf2_ros::Buffer tf_buffer_;
 
   tf2_ros::TransformListener tf_listener_;
+
+  ros::Subscriber subscriber_;
 };
 
 }  // namespace twist_2d

--- a/include/fuse_rl/unicycle_2d/ignition.h
+++ b/include/fuse_rl/unicycle_2d/ignition.h
@@ -95,6 +95,26 @@ public:
   ~Ignition() = default;
 
   /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   *
+   * As a very special case, we are overriding the start() method instead of providing an onStart() implementation.
+   * This is because the Ignition sensor calls reset() on the optimizer, which in turn calls stop() and start(). If we
+   * used the AsyncSensorModel implementations of start() and stop(), the system would hang inside of one callback
+   * function while waiting for another callback to complete.
+   */
+  void start() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   *
+   * As a very special case, we are overriding the stop() method instead of providing an onStop() implementation.
+   * This is because the Ignition sensor calls reset() on the optimizer, which in turn calls stop() and start(). If we
+   * used the AsyncSensorModel implementations of start() and stop(), the system would hang inside of one callback
+   * function while waiting for another callback to complete.
+   */
+  void stop() override;
+
+  /**
    * @brief Triggers the publication of a new prior transaction at the supplied pose
    */
   void subscriberCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg);
@@ -118,16 +138,26 @@ protected:
   void onInit() override;
 
   /**
+   * @brief Process a received pose from one of the ROS comm channels
+   *
+   * This method validates the input pose, resets the optimizer, then constructs and sends the initial state
+   * constraints (by calling sendPrior()).
+   *
+   * @param[in] pose - The pose and covariance to use for the prior constraints on (x, y, yaw)
+   */
+  void process(const geometry_msgs::PoseWithCovarianceStamped& pose);
+
+  /**
    * @brief Create and send a prior transaction based on the supplied pose
    *
    * The unicycle 2d state members not included in the pose message (x_vel, y_vel, yaw_vel, x_acc, y_acc) will use
    * the initial state values and standard deviations configured on the parameter server.
    *
    * @param[in] pose - The pose and covariance to use for the prior constraints on (x, y, yaw)
-   * @param[in] reset_optimizer - Flag indicating the reset service should be called before sending the transaction
-   * @return True if the transaction was sent successfully, false otherwise
    */
-  void process(const geometry_msgs::PoseWithCovarianceStamped& pose, const bool reset_optimizer);
+  void sendPrior(const geometry_msgs::PoseWithCovarianceStamped& pose);
+
+  bool initial_transaction_sent_;  //!< Flag indicating an initial transaction has been sent already
 
   fuse_core::UUID device_id_;  //!< The UUID of this device
 

--- a/include/fuse_rl/unicycle_2d/ignition.h
+++ b/include/fuse_rl/unicycle_2d/ignition.h
@@ -44,6 +44,8 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <ros/ros.h>
 
+#include <atomic>
+
 
 namespace fuse_rl
 {
@@ -156,6 +158,8 @@ protected:
    * @param[in] pose - The pose and covariance to use for the prior constraints on (x, y, yaw)
    */
   void sendPrior(const geometry_msgs::PoseWithCovarianceStamped& pose);
+
+  std::atomic_bool started_;  //!< Flag indicating the sensor has been started
 
   bool initial_transaction_sent_;  //!< Flag indicating an initial transaction has been sent already
 

--- a/include/fuse_rl/unicycle_2d/model.h
+++ b/include/fuse_rl/unicycle_2d/model.h
@@ -146,6 +146,11 @@ protected:
   void onInit() override;
 
   /**
+   * @brief Reset the internal state history before starting
+   */
+  void onStart() override;
+
+  /**
    * @brief Update all of the estimated states in the state history container using the optimized values from the graph
    * @param[in] graph         The graph object containing updated variable values
    * @param[in] state_history The state history object to be updated

--- a/src/acceleration_2d/model.cpp
+++ b/src/acceleration_2d/model.cpp
@@ -70,10 +70,19 @@ void Model::onInit()
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
   }
-  else
+}
+
+void Model::onStart()
+{
+  if (!params_.indices.empty())
   {
     subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Model::process, this);
   }
+}
+
+void Model::onStop()
+{
+  subscriber_.shutdown();
 }
 
 void Model::process(const geometry_msgs::AccelWithCovarianceStamped::ConstPtr& msg)

--- a/src/imu_2d/model.cpp
+++ b/src/imu_2d/model.cpp
@@ -77,10 +77,22 @@ void Model::onInit()
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
   }
-  else
+}
+
+void Model::onStart()
+{
+  if (!params_.orientation_indices.empty() ||
+      !params_.linear_acceleration_indices.empty() ||
+      !params_.angular_velocity_indices.empty())
   {
+    previous_pose_.reset();
     subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Model::process, this);
   }
+}
+
+void Model::onStop()
+{
+  subscriber_.shutdown();
 }
 
 void Model::process(const sensor_msgs::Imu::ConstPtr& msg)

--- a/src/odometry_2d/model.cpp
+++ b/src/odometry_2d/model.cpp
@@ -75,10 +75,23 @@ void Model::onInit()
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
   }
-  else
+}
+
+void Model::onStart()
+{
+  if (!params_.position_indices.empty() ||
+      !params_.orientation_indices.empty() ||
+      !params_.linear_velocity_indices.empty() ||
+      !params_.angular_velocity_indices.empty())
   {
+    previous_pose_.reset();
     subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Model::process, this);
   }
+}
+
+void Model::onStop()
+{
+  subscriber_.shutdown();
 }
 
 void Model::process(const nav_msgs::Odometry::ConstPtr& msg)

--- a/src/pose_2d/model.cpp
+++ b/src/pose_2d/model.cpp
@@ -71,10 +71,20 @@ void Model::onInit()
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
   }
-  else
+}
+
+void Model::onStart()
+{
+  if (!params_.position_indices.empty() ||
+      !params_.orientation_indices.empty())
   {
     subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Model::process, this);
   }
+}
+
+void Model::onStop()
+{
+  subscriber_.shutdown();
 }
 
 void Model::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg)

--- a/src/twist_2d/model.cpp
+++ b/src/twist_2d/model.cpp
@@ -71,10 +71,20 @@ void Model::onInit()
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
   }
-  else
+}
+
+void Model::onStart()
+{
+  if (!params_.linear_indices.empty() ||
+      !params_.angular_indices.empty())
   {
     subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Model::process, this);
   }
+}
+
+void Model::onStop()
+{
+  subscriber_.shutdown();
 }
 
 void Model::process(const geometry_msgs::TwistWithCovarianceStamped::ConstPtr& msg)

--- a/src/unicycle_2d/model.cpp
+++ b/src/unicycle_2d/model.cpp
@@ -123,6 +123,12 @@ void Model::onInit()
   device_id_ = fuse_variables::loadDeviceId(private_node_handle_);
 }
 
+void Model::onStart()
+{
+  timestamp_manager_.clear();
+  state_history_.clear();
+}
+
 void Model::generateMotionModel(
   const ros::Time& beginning_stamp,
   const ros::Time& ending_stamp,


### PR DESCRIPTION
I have added `start()` and `stop()` methods to the MotionModel, SensorModel, and Publisher base classes in this PR (locusrobotics/fuse#75). This PR updates all of the fuse_rl sensor models, motion models, and publishers to support the new `start()` and `stop()` methods.

For most plugins, the `start()` method clears some internal state, then subscribes to a topic. And the `stop()` method simply shuts down the subscriber.

A notable exception is the Ignition sensor. This one is annoying and complicated. The desired flow for this sensor is:
1. User calls ignition's set_pose service
2. Ignition::setPoseCallback calls optimizer's reset service
3. Optimizer::resetCallback calls Ignition::stop()
4. Ignition::stop() shuts down all the subscribers and services
5. Optimizer::resetCallback clears internal optimizer state
6. Optimizer::resetCallback calls Ignition::start()
7. Ignition::start() resubscribes and readvertises
8. Optimizer::resetCallback completes
9. Ignition::setPoseCallback resumes, and sends a new initial state transaction to the optimizer
10. Ignition::setPoseCallback completes
11. User is notified of service call completion

There are a couple of issues with the above flow:

At (3), the Optimizer calls the Ignition `stop()` method. As an AsyncSensorModel, the `stop()` method will insert a call to `onStop()` into the Ignition callback queue then block until it has been executed. However, we are already inside the Ignition `setPoseCallback()`. This prevents the `onStop()` from ever being executed, so we block indefinitely. There are two options: (a) increase the spinner thread count so that multiple callbacks may be executed at once. This seems a bit needless. (b) Implement the required logic directly in the `stop()` method instead of inserting a call to `onStop()` into the callback queue. This means that code will execute in multiple threads, so proper use of mutexes, etc must be considered. At the moment I have chosen option (b).

At (4), when the service is shutdown, all callbacks are removed. Even currently running callbacks are terminated. This means that when `stop()` shuts down the service in the middle of the `setPoseCallback()` callback, the `setPoseCallback()` stops executing in the middle of the callback. The second half of the callback never runs. To work around this feature, the Ignition sensor uses a `running_` flag to control whether callbacks are serviced, rather than shutting down the service. This has the slightly undesirable side affect of having a service advertised and callable by the user, but will return an error because the Ignition sensor is in the wrong state. In practice, this should be basically impossible to happen.

PR locusrobotics/fuse#75 will need to be merged before the CI will build correctly.